### PR TITLE
fix org.freedesktop.DBus.Error.ServiceUnknown

### DIFF
--- a/manifests/master/eu.tiliado.NuvolaApp.yml
+++ b/manifests/master/eu.tiliado.NuvolaApp.yml
@@ -43,6 +43,7 @@ finish-args:
   - --talk-name=org.xfce.SessionManager
   # MPRIS
   - --own-name=org.mpris.MediaPlayer2.NuvolaApp@APP_ID_UNIQUE@
+  - --own-name=org.mpris.MediaPlayer2.chromium.*
   # Unity launcher API
   - --talk-name=com.canonical.Unity
   # Notifications


### PR DESCRIPTION
Fix
```
[0101/154737.664433:ERROR:bus.cc(554)] Failed to get the ownership of org.mpris.MediaPlayer2.chromium.instance2: org.freedesktop.DBus.Error.ServiceUnknown
```

with the same solution as seen in https://github.com/flathub/com.google.Chrome/issues/54